### PR TITLE
Fix undefined method add_routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 # Put your extension routes here.
-Spree::Core::Engine.add_routes do
+Spree::Core::Engine.routes.draw do
   get 'currency/:id' => 'currency#set', as: :currency
   namespace :admin do
     resources :currencies


### PR DESCRIPTION
Using with spree 2.0.4 was throwing undefiled method add_routes.
