### PR TITLE
Fix for spree 2-2 and Money > 6.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,9 @@ group :test do
   gem 'coffee-script'
 end
 
-gem 'spree', github: 'spree/spree', branch: '2-1-stable'
+gem 'spree', github: 'spree/spree', branch: '2-2-stable'
 # provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-1-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-2-stable'
+gem 'monetize'
 
 gemspec

--- a/app/models/spree/money_decorator.rb
+++ b/app/models/spree/money_decorator.rb
@@ -1,7 +1,7 @@
 Spree::Money.class_eval do
 
   def initialize(amount, options = {})
-      @money = ::Money.parse([amount, Spree::Currency.current.char_code].join)
+      @money = Monetize.parse([amount, Spree::Currency.current.char_code].join)
       @options = {}
       @options[:with_currency] = Spree::Config[:display_currency]
       @options[:symbol_position] = Spree::Config[:currency_symbol_position].to_sym


### PR DESCRIPTION
Small fix, for Spree 2-2 and Money > 6.1.x (Money.parse removed).
